### PR TITLE
Update copy button text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@
   * { box-sizing: border-box; margin: 0; padding: 0; }
   html, body { height: 100%; }
   
-  body {
+body {
     font-family: 'Inter', system-ui, Helvetica, Arial, sans-serif;
     background: var(--russian-violet);
     color: var(--text-light);
@@ -17,6 +17,7 @@
     align-items: flex-start;
     justify-content: center;
     padding: 2rem;
+    overflow-x: hidden;
   }
   
   .container {
@@ -105,16 +106,13 @@
     position: fixed;
     bottom: 1.5rem;
     right: 1.5rem;
-    width: 56px;
-    height: 56px;
-    border-radius: 50%;
+    padding: 0.8rem 1.2rem;
+    border-radius: 6px;
     border: none;
     background: var(--accent-pink);
     color: #1A0128;
-    font-size: 1.35rem;
-    font-weight: 700;
-    display: grid;
-    place-items: center;
+    font-size: 1rem;
+    font-weight: 600;
     cursor: pointer;
     box-shadow: 0 2px 6px rgba(0,0,0,0.3);
     transition: transform 0.15s, filter 0.15s;
@@ -125,4 +123,58 @@
     color: #252525;
     cursor: not-allowed;
     box-shadow: none;
-  }  
+  }
+
+  /* ------- Copy Prompt + JSON button ------- */
+  #copyPromptBtn {
+    position: fixed;
+    bottom: 4.5rem;
+    right: 1.5rem;
+    padding: 0.8rem 1.2rem;
+    border-radius: 6px;
+    border: none;
+    background: var(--accent-cyan);
+    color: #002021;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+    transition: transform 0.15s, filter 0.15s;
+  }
+  #copyPromptBtn:hover:not(:disabled) { transform: translateY(-2px); filter: brightness(1.1); }
+  #copyPromptBtn:disabled {
+    background: #6E6380;
+    color: #252525;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+
+  /* ------- Sliding form section ------- */
+  #slideWrapper {
+    display: flex;
+    width: 200%;
+    transition: transform 0.4s ease-in-out;
+  }
+  #slideWrapper.show-form { transform: translateX(-50%); }
+  .app-section { width: 100%; flex-shrink: 0; }
+
+  #promptSection {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding-top: 2rem;
+  }
+  #promptForm input[type="text"] {
+    width: 100%;
+    max-width: 320px;
+    padding: 0.6rem 0.8rem;
+    border-radius: 6px;
+    border: 1px solid var(--accent-cyan);
+    color: #000;
+  }
+  #promptForm label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }

--- a/index.html
+++ b/index.html
@@ -61,6 +61,8 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <div id="slideWrapper">
+    <section id="mainSection" class="app-section">
   <div class="container">
     <h1>HTML → JS String-Literal Converter</h1>
 
@@ -76,7 +78,18 @@
     </pre>
   </div>
 
-  <button id="copyBtn" aria-label="Copy" title="Copy to clipboard" disabled>❐</button>
+  <button id="copyPromptBtn" aria-label="Copy Prompt and JSON" title="Copy prompt and JSON" disabled>Copy Prompt + JSON</button>
+  <button id="copyBtn" aria-label="Copy JSON" title="Copy to clipboard" disabled>Copy JSON</button>
+
+    </section>
+    <section id="promptSection" class="app-section">
+      <form id="promptForm">
+        <input type="text" placeholder="Problem Statement">
+        <input type="text" placeholder="Problem Statement">
+        <label><input type="checkbox"> Suggestion Solution</label>
+      </form>
+    </section>
+  </div>
 
   <!-- Script separado -->
   <script src="js/main.js" defer></script>

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const output          = document.getElementById('output');
   const codeEl          = document.getElementById('outputCode');
   const copyBtn         = document.getElementById('copyBtn');
+  const copyPromptBtn   = document.getElementById('copyPromptBtn');
+  const slideWrapper    = document.getElementById('slideWrapper');
 
   /* util: convert value → JS literal */
   function toLiteral(x, indent = 0) {
@@ -225,7 +227,8 @@ function processContent(htmlString) {
   if (typeof codeEl !== 'undefined' && typeof toLiteral === 'function' && typeof copyBtn !== 'undefined') {
     codeEl.textContent = '[\n' + result.map((o) => '  ' + toLiteral(o, 2)).join(',\n') + '\n]';
     codeEl.classList.remove('reveal'); void codeEl.offsetWidth; codeEl.classList.add('reveal');
-    copyBtn.disabled = (result.length === 0); copyBtn.textContent = '❐';
+    copyBtn.disabled = (result.length === 0); copyBtn.textContent = 'Copy JSON';
+    if (copyPromptBtn) copyPromptBtn.disabled = (result.length === 0);
   }
   return result;
 }
@@ -257,10 +260,16 @@ function processContent(htmlString) {
     if (copyBtn.disabled) return;
     try {
       await navigator.clipboard.writeText(codeEl.textContent);
-      copyBtn.textContent = '✓';
-      setTimeout(() => (copyBtn.textContent = '❐'), 1500);
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => (copyBtn.textContent = 'Copy JSON'), 1500);
     } catch (err) {
       alert('Copy failed: ' + err);
     }
   });
+
+  if (copyPromptBtn) {
+    copyPromptBtn.addEventListener('click', () => {
+      slideWrapper?.classList.add('show-form');
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- replace copy button icon with `Copy JSON` text
- adjust copy button styling for text-based layout
- update copy button behavior in JavaScript
- add a `Copy Prompt + JSON` button and slide-in form

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68458272630c8327868d33e19a44e1db