### PR TITLE
Add Copy Prompt + JSON feature

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -125,4 +125,52 @@
     color: #252525;
     cursor: not-allowed;
     box-shadow: none;
-  }  
+  }
+
+  #copyPromptBtn {
+    position: fixed;
+    bottom: 6.5rem;
+    right: 1.5rem;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    border: none;
+    background: var(--accent-cyan);
+    color: #002021;
+    font-size: 0.75rem;
+    font-weight: 700;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+    transition: transform 0.15s, filter 0.15s;
+  }
+  #copyPromptBtn:hover:not(:disabled) { transform: translateY(-2px); filter: brightness(1.1); }
+
+  #promptContainer {
+    display: none;
+    width: 100%;
+    background: #26123C;
+    border: 1px solid var(--accent-pink);
+    border-radius: 8px;
+    padding: 1.2rem;
+    min-height: 220px;
+    max-height: 60vh;
+    overflow: auto;
+  }
+  #promptCode {
+    display: block;
+    font-family: 'Roboto Mono', monospace;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  body.show-prompt #promptContainer { display: block; animation: slideIn 0.5s forwards; }
+  body.show-prompt #output,
+  body.show-prompt #copyBtn,
+  body.show-prompt #copyPromptBtn { animation: slideOut 0.5s forwards; pointer-events: none; }
+
+  @keyframes slideOut { from { transform: translateX(0); opacity:1; } to { transform: translateX(-100%); opacity:0; } }
+  @keyframes slideIn { from { transform: translateX(100%); opacity:0; } to { transform: translateX(0); opacity:1; } }

--- a/index.html
+++ b/index.html
@@ -74,8 +74,12 @@
     <pre id="output" aria-live="polite">
       <code id="outputCode">The JavaScript string literal will appear here…</code>
     </pre>
+    <pre id="promptContainer" aria-live="polite">
+      <code id="promptCode"></code>
+    </pre>
   </div>
 
+  <button id="copyPromptBtn" aria-label="Copy Prompt + JSON" title="Copy Prompt + JSON">P+J</button>
   <button id="copyBtn" aria-label="Copy" title="Copy to clipboard" disabled>❐</button>
 
   <!-- Script separado -->

--- a/js/main.js
+++ b/js/main.js
@@ -243,6 +243,9 @@ function processContent(htmlString) {
     if (!file) return;
     fileNameDisplay.textContent = file.name;
     document.body.classList.remove('show-prompt');
+    output.style.display = '';
+    copyBtn.style.display = '';
+    copyPromptBtn.style.display = '';
     const reader = new FileReader();
     reader.onload = ev => {
       try {
@@ -275,6 +278,11 @@ function processContent(htmlString) {
     const combined = PROMPT_TEXT + codeEl.textContent;
     promptCodeEl.textContent = combined;
     document.body.classList.add('show-prompt');
+    setTimeout(() => {
+      output.style.display = 'none';
+      copyBtn.style.display = 'none';
+      copyPromptBtn.style.display = 'none';
+    }, 500);
     try {
       await navigator.clipboard.writeText(combined);
       copyPromptBtn.textContent = '✓';

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const fileNameDisplay = document.getElementById('fileName');
   const output          = document.getElementById('output');
   const codeEl          = document.getElementById('outputCode');
+  const promptContainer = document.getElementById('promptContainer');
+  const promptCodeEl    = document.getElementById('promptCode');
   const copyBtn         = document.getElementById('copyBtn');
+  const copyPromptBtn   = document.getElementById('copyPromptBtn');
+
+  const PROMPT_TEXT = 'Prompt:\n';
 
   /* util: convert value → JS literal */
   function toLiteral(x, indent = 0) {
@@ -237,6 +242,7 @@ function processContent(htmlString) {
     const file = e.target.files[0];
     if (!file) return;
     fileNameDisplay.textContent = file.name;
+    document.body.classList.remove('show-prompt');
     const reader = new FileReader();
     reader.onload = ev => {
       try {
@@ -259,6 +265,20 @@ function processContent(htmlString) {
       await navigator.clipboard.writeText(codeEl.textContent);
       copyBtn.textContent = '✓';
       setTimeout(() => (copyBtn.textContent = '❐'), 1500);
+    } catch (err) {
+      alert('Copy failed: ' + err);
+    }
+  });
+
+  copyPromptBtn.addEventListener('click', async () => {
+    if (copyBtn.disabled) return;
+    const combined = PROMPT_TEXT + codeEl.textContent;
+    promptCodeEl.textContent = combined;
+    document.body.classList.add('show-prompt');
+    try {
+      await navigator.clipboard.writeText(combined);
+      copyPromptBtn.textContent = '✓';
+      setTimeout(() => (copyPromptBtn.textContent = 'P+J'), 1500);
     } catch (err) {
       alert('Copy failed: ' + err);
     }


### PR DESCRIPTION
## Summary
- add Copy Prompt + JSON button above the existing copy button
- add prompt output area and sliding transition styles
- implement slide and copy logic in JavaScript

## Testing
- `npm test` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_e_6845867559fc8327a60652ab3a19f680